### PR TITLE
cleanup php warning

### DIFF
--- a/thesslstore_module.php
+++ b/thesslstore_module.php
@@ -2121,7 +2121,7 @@ class ThesslstoreModule extends Module {
 
             $this->log($this->api_partner_code . "|ssl-refund-request", serialize($refundReq), "input", true);
             $refundRes = $api->order_refundrequest($refundReq);
-            if(!$refundRes->AuthResponse->Message[0])
+            if(!($refundRes->AuthResponse->Message[0]))
             {
                 $errorMessage=$refundRes->AuthResponse->Message;
             }


### PR DESCRIPTION
Fixes warning in log file
```
general.WARNING: E_WARNING: Trying to access array offset on value of type null {"code":2,"message":"Try
ing to access array offset on value of type null","file":"components/modules/thesslstore_module/thesslstore_module.php","li
ne":2124}
```